### PR TITLE
Add tmp/e2e/ to .gitignore (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@
 !/tmp/storage/
 !/tmp/storage/.keep
 
+# Ignore e2e test fixtures.
+tmp/e2e/
+
 /public/assets
 
 # Ignore master key for decrypting credentials and more.


### PR DESCRIPTION
Closes #35

Adds an explicit `tmp/e2e/` entry to `.gitignore` for e2e test fixtures generated by `bundle exec ruby tests/e2e/run.rb`.

Note: The existing `/tmp/*` rule already covers this path (verified via `git check-ignore -v`). This explicit entry is added for clarity, as requested in the issue.