### PR TITLE
Issue 49: Add tmp/e2e to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*
+tmp/e2e/
 !/log/.keep
 !/tmp/.keep
 


### PR DESCRIPTION
## Summary
- Add explicit `tmp/e2e/` entry to `.gitignore` for e2e fixture artifacts.

Closes #49
